### PR TITLE
find-index with empty array does not return -1

### DIFF
--- a/test/test-find-index.js
+++ b/test/test-find-index.js
@@ -37,6 +37,11 @@ describe('findIndex', function () {
     delete this.str;
     done();
   });
+  it('should return -1 in an empty list', function (done) {
+    var arr = [];
+    expect(findIndex(arr, function (v) { return v === 1; })).to.equal(-1);
+    done();
+  });
   it('should get the index of an item in an array/string that passes a given function', function (done) {
     var arr = this.arr;
     expect(findIndex(arr, isObject)).to.equal(0);


### PR DESCRIPTION
this test currently breaks. I would think an empty array should return -1 if there is no elements in it... the `list.length` check I would imagine to be the culprit in `find-index`, but it's there to protect against something else at the moment, so I'm not sure what the correct fix would be :)
