### PR TITLE
fix envIs and equals example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ clone(obj); // { foo: 1, bar: 2 }
 Functional version of str === process.env.NODE_ENV
 
 ```js
-var exists = require('101/exists');
+var envIs = require('101/envIs');
 // process.env.NODE_ENV = development
 envIs('development');     // true
 envIs('production');      // false
@@ -76,11 +76,11 @@ envIs('development', 'production'); // true
 Functional version of === , supports partial functionality
 
 ```js
-var exists = require('101/exists');
+var equals = require('101/equals');
 
-exists(1, 1);            // true
+equals(1, 1);            // true
 [1,2,3].some(equals(1)); // true
-exists(1, '1');          // false
+equals(1, '1');          // false
 ```
 
 ## exists


### PR DESCRIPTION
The code examples for envIs and equals were using exists rather than the ones specified.
