### PR TITLE
Build ES6 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 out
 jsdoc.conf
+/es6/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+out
+jsdoc.conf

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,11 @@
+var basename = require('basename');
+var clone = require('clone');
 var gulp = require('gulp');
 var replace = require('gulp-replace');
+var stripComments = require('strip-comments');
+var stream = require('through2').obj;
+
+var findIndex = require('./find-index');
 
 
 //
@@ -24,11 +30,50 @@ gulp.task('default', ['es6']);
 //
 
 var requireCall = /^var ([^ ]+) = require\('(\.\/[a-z-]+)'\);$/mg;
-var exportsAssignment = /^module.exports = /mg;
+var exportsAssignment = /^module\.exports = /mg;
 
 gulp.task('es6', function () {
+  var files = [];
+
   return gulp.src('*.js')
+
+    // Do the simple search'n'replace.
     .pipe(replace(requireCall, "import $1 from '$2';"))
     .pipe(replace(exportsAssignment, 'export default '))
+
+    // Skip a file if the string 'require(' or 'module.exports' is still there.
+    .pipe(stream(function (file, encoding, done) {
+      var rawContents = stripComments(file.contents.toString());
+      if (/(^|\s)require\s*\(/.test(rawContents)) return done();
+      if (/(^|\s)module\.exports[^w]/.test(rawContents)) return done();
+
+      files.push(file);
+      done();
+
+    // Find modules which depend on skipped ones and remove them from the stream.
+    }, function (done) {
+      var safeFiles = (function removeUnrooted (files) {
+        var availableModules = files.map(function (file) { return basename(file.path); });
+        var unrootedIndex = findIndex(files, function isUnrooted (file) {
+          var match;
+          var importStatement = /import [^ ]+ from '.\/([a-z-]+)';/g;
+          var contents = file.contents.toString();
+          while ((match = importStatement.exec(contents))) {
+            if (availableModules.indexOf(match[1]) == -1) return true;
+          }
+        });
+
+        if (unrootedIndex >= 0) {
+          files.splice(unrootedIndex, 1);
+          return removeUnrooted(clone(files));
+        }
+        else return clone(files);
+      })(files);
+
+      safeFiles.forEach(this.push.bind(this));
+      done();
+    }))
+
+    // Save the processed files.
     .pipe(gulp.dest('es6'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,34 @@
+var gulp = require('gulp');
+var replace = require('gulp-replace');
+
+
+//
+// `gulp`
+// ------
+// Runs `gulp es6`.
+//
+
+gulp.task('default', ['es6']);
+
+
+//
+// `gulp es6`
+// ----------
+// Converts CommonJS modules to ES6 modules through a simple search'n'replace – and pipes them to
+// the directory es6/ . If we can't fully convert a module, we skip it to ensure a solid code base
+// compatible with any ES6 environment and transpiler.
+//
+// In order to get converted, a function can't depend on anything but other 101/... functions. The
+// `require` calls and `module` assignments must match the patterns `requireCall` and
+// `exportsAssignment` defined below.
+//
+
+var requireCall = /^var ([^ ]+) = require\('(\.\/[a-z-]+)'\);$/mg;
+var exportsAssignment = /^module.exports = /mg;
+
+gulp.task('es6', function () {
+  return gulp.src('*.js')
+    .pipe(replace(requireCall, "import $1 from '$2';"))
+    .pipe(replace(exportsAssignment, 'export default '))
+    .pipe(gulp.dest('es6'));
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "homepage": "https://github.com/tjmehta/101",
   "devDependencies": {
     "coveralls": "^2.11.2",
+    "gulp": "^3.8.10",
+    "gulp-replace": "^0.5.0",
     "lab": "^4.6.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "lab -c test",
-    "test-watch": "nodemon --exec lab -c test"
+    "test-watch": "nodemon --exec lab -c test",
+    "postinstall": "gulp"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "lab -c test",
     "test-watch": "nodemon --exec lab -c test",
-    "postinstall": "gulp"
+    "prepublish": "gulp"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,19 +31,18 @@
   },
   "homepage": "https://github.com/tjmehta/101",
   "devDependencies": {
-    "basename": "^0.1.2",
-    "clone": "^0.1.19",
     "coveralls": "^2.11.2",
-    "gulp": "^3.8.10",
-    "gulp-replace": "^0.5.0",
-    "lab": "^4.6.2",
-    "strip-comments": "^0.3.2",
-    "through2": "^0.6.3"
+    "lab": "^4.6.2"
   },
   "dependencies": {
+    "basename": "^0.1.2",
     "clone": "^0.1.18",
     "deep-eql": "^0.1.3",
     "extend": "^1.3.0",
-    "keypather": "^1.7.5"
+    "gulp": "^3.8.10",
+    "gulp-replace": "^0.5.0",
+    "keypather": "^1.7.5",
+    "strip-comments": "^0.3.2",
+    "through2": "^0.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,14 @@
   },
   "homepage": "https://github.com/tjmehta/101",
   "devDependencies": {
+    "basename": "^0.1.2",
+    "clone": "^0.1.19",
     "coveralls": "^2.11.2",
     "gulp": "^3.8.10",
     "gulp-replace": "^0.5.0",
-    "lab": "^4.6.2"
+    "lab": "^4.6.2",
+    "strip-comments": "^0.3.2",
+    "through2": "^0.6.3"
   },
   "dependencies": {
     "clone": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
   },
   "homepage": "https://github.com/tjmehta/101",
   "devDependencies": {
+    "basename": "^0.1.2",
     "coveralls": "^2.11.2",
-    "lab": "^4.6.2"
+    "lab": "^4.6.2",
+    "gulp": "^3.8.10",
+    "gulp-replace": "^0.5.0",
+    "strip-comments": "^0.3.2",
+    "through2": "^0.6.3"
   },
   "dependencies": {
-    "basename": "^0.1.2",
     "clone": "^0.1.18",
     "deep-eql": "^0.1.3",
     "extend": "^1.3.0",
-    "gulp": "^3.8.10",
-    "gulp-replace": "^0.5.0",
-    "keypather": "^1.7.5",
-    "strip-comments": "^0.3.2",
-    "through2": "^0.6.3"
+    "keypather": "^1.7.5"
   }
 }


### PR DESCRIPTION
So @tjmehta I've had a go at #38 . Before I even read your comment on the issue :)

I've gone for the 100% ES6-safe variant – without functions depending on CJS modules, functions depending on these functions, etc. They're simply excluded from the build.

To keep the workload sensible I've presumed that the imports and exports keep being formatted the same way as they are now. A file formatted differently doesn't get included in the build.

I don't know how to exclude the gulpfile from the code coverage checks, so chances are test coverage falls from 100%.