### PR TITLE
Changed 100's to hundreds

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I usually agree with this philosophy; however, while in practice, adherence to t
 can become quite annoying for micro-modules (like those in 101):
 * Micro-modules existance throughout a project can change very frequently, because of this one may find
 themselves constantly updating their package.json (repeatedly adding and removing the same micro-modules).
-* Unbundling micro-modules can lead to projects with 100's of dependencies which can be tedious to maintain.
+* Unbundling micro-modules can lead to projects with hundreds of dependencies which can be tedious to maintain.
 
 
 


### PR DESCRIPTION
Approximate numbers should be spelled out. 100 is confusing given that it can be confused for 101, and the apostrophe was errant.