### PR TITLE
fix typo in jsdoc

### DIFF
--- a/or.js
+++ b/or.js
@@ -1,10 +1,10 @@
 /**
- * @module 101/and
+ * @module 101/or
  */
 
 /**
  * Functional version of ||
- * @function module:101/and
+ * @function module:101/or
  * @param {*} a - any value
  * @param {*} b - any value
  * @return {boolean} a || b


### PR DESCRIPTION
Small typo in `or`