### PR TITLE
add exclusive or (xor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,20 @@ var obj = {
 set(obj, 'foo', 100); // { foo: 100, bar:2 }
 ```
 
+## xor
+
+Exclusive or
+Works great with `array.reduce`.
+
+```js
+var xor = require('101/xor');
+
+xor(true, true);   // false
+xor(true, false);  // true
+xor(false, true);  // true
+xor(false, false); // false
+```
+
 ## License
 
 MIT

--- a/test/test-xor.js
+++ b/test/test-xor.js
@@ -1,0 +1,23 @@
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+
+var describe = lab.describe;
+var it = lab.it;
+var expect = Lab.expect;
+
+var xor = require('../xor');
+
+describe('xor', function() {
+  it('should work with reduce', function (done) {
+    expect([true, true, true].reduce(xor, true)).to.eql(false);
+    expect([false, false, false].reduce(xor, false)).to.eql(false);
+    expect([false, false, false].reduce(xor, true)).to.eql(true);
+    expect([true, false, false].reduce(xor)).to.eql(true);
+    expect([false, true, false].reduce(xor)).to.eql(true);
+    expect([false, false, true].reduce(xor)).to.eql(true);
+    expect([false, true, true].reduce(xor)).to.eql(false);
+    expect([true, false, true].reduce(xor)).to.eql(false);
+    expect([true, true, false].reduce(xor)).to.eql(false);
+    done();
+  });
+});

--- a/xor.js
+++ b/xor.js
@@ -1,0 +1,17 @@
+/**
+ * @module 101/xor
+ */
+
+/**
+ * Exclusive or
+ * @function module:101/xor
+ * @param {*} a - any value
+ * @param {*} b - any value
+ * @return {boolean} a xor b
+ */
+
+module.exports = xor;
+
+function xor (a, b) {
+  return !(!a && !b) && !(a && b);
+}


### PR DESCRIPTION
Proposal to add an exclusive or (`xor`) function.

```js
var xor = require('101/xor');

xor(true, true);   // false
xor(true, false);  // true
xor(false, true);  // true
xor(false, false); // false
```
