### PR TITLE
RegExp pick

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ var passAny = require('101/pass-any');
 ## pick
 
 Returns a new object with the specified keys (with key values from obj).
-Supports partial functionality (great with array functions, like map).
+Supports regular expressions and partial functionality (great with array functions, like map).
 
 ```js
 var pick = require('101/pick');
@@ -402,6 +402,7 @@ var obj = {
 };
 
 pick(obj, 'foo');          // { foo: 1 }
+pick(obj, RegExp('oo$'));  // { foo: 1 }
 pick(obj, ['foo']);        // { foo: 1 }
 pick(obj, ['foo', 'bar']); // { foo: 1, bar: 2 }
 

--- a/defaults.js
+++ b/defaults.js
@@ -5,16 +5,25 @@
 /**
  * Mixes in properties from source into target when
  * the property is not a property of `target`
- * @param  {Object} target Mix into
+ * @param  {Object} [target] Mix into
  * @param  {Object} source The defaults description
  * @return {Object}        THe resulting target
  */
-module.exports = function (target, source) {
-  target = target || {};
+module.exports = defaults;
 
-  for (var key in source) {
-    if (!(key in target)) target[ key ] = source[ key ];
+function defaults (target, source) {
+  if (arguments.length === 1) {
+    source = target;
+    return function (target) {
+      return defaults(target, source);
+    };
   }
-
-  return target;
-};
+  target = target || {};
+  if (!source) {
+    return target;
+  }
+  return Object.keys(source).reduce(function (target, key) {
+    target[key] = target[key] || source[key];
+    return target;
+  }, target);
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "common javascript utils that can be required selectively that assume es5+",
   "main": "index.js",
   "scripts": {
-    "test": "lab -c test",
+    "test": "lab -c -t 100 test",
     "test-watch": "nodemon --exec lab -c test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "101",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "common javascript utils that can be required selectively that assume es5+",
   "main": "index.js",
   "scripts": {

--- a/pick.js
+++ b/pick.js
@@ -68,7 +68,7 @@ function copyWithString (from, to) {
 
 function copyWithRegExp (from, to, regexp) {
   return function (key) {
-    if (regexp.test(key) && !(key in to)) {
+    if (regexp.test(key)) {
       to[key] = from[key];
     }
   };

--- a/pick.js
+++ b/pick.js
@@ -9,7 +9,7 @@ var isObject = require('./is-object');
  * When only keys are specified pick returns a partial-function which accepts obj.
  * @function module:101/pick
  * @param {object} [obj] - object whose keys are picked
- * @param {string|array} keys... - keys which will be taken from obj (can be specifieds as args (strings and/or arrays)
+ * @param {string|regexp|array} keys... - keys which will be taken from obj, can be specifieds as args (strings, regular epxressions, and/or arrays)
  * @return {object|function} Object with only the keys specified from the original obj or Partial-function pick (which accepts obj) and returns an object
  */
 module.exports = function () {
@@ -28,12 +28,22 @@ module.exports = function () {
 function pick (obj, args) {
   var keys = [];
   var regexps = [];
-  args.forEach(function (matcher) {
-    if (matcher instanceof RegExp || matcher[0] instanceof RegExp) {
-      regexps = regexps.concat(matcher);
+  function concatElement(el) {
+    if (el instanceof RegExp) {
+      regexps = regexps.concat(el);
     }
     else {
-      keys = keys.concat(matcher);
+      keys = keys.concat(el);
+    }
+  }
+  args.forEach(function (element) {
+    if (Array.isArray(element)) {
+      element.forEach(function(subelement){
+        concatElement(subelement);
+      });
+    }
+    else {
+      concatElement(element);
     }
   });
   var out = {};

--- a/pick.js
+++ b/pick.js
@@ -27,17 +27,38 @@ module.exports = function () {
 
 function pick (obj, args) {
   var keys = [];
-  args.forEach(function (key) {
-    keys = keys.concat(key);
+  var regexps = [];
+  args.forEach(function (matcher) {
+    if (matcher instanceof RegExp || matcher[0] instanceof RegExp) {
+      regexps = regexps.concat(matcher);
+    }
+    else {
+      keys = keys.concat(matcher);
+    }
   });
   var out = {};
-  keys.forEach(copy(obj, out));
+  if (keys.length > 0) {
+    keys.forEach(copyWithString(obj, out));
+  }
+  if (regexps.length > 0) {
+    regexps.forEach(function(regexp){
+      Object.keys(obj).forEach(copyWithRegExp(obj, out, regexp));
+    });
+  }
   return out;
 }
 
-function copy (from, to) {
+function copyWithString (from, to) {
   return function (key) {
     if (key in from) {
+      to[key] = from[key];
+    }
+  };
+}
+
+function copyWithRegExp (from, to, regexp) {
+  return function (key) {
+    if (regexp.test(key) && !(key in to)) {
       to[key] = from[key];
     }
   };

--- a/test/test-defaults.js
+++ b/test/test-defaults.js
@@ -38,10 +38,53 @@ describe('defaults', function () {
       qux: 3
     };
 
-    var c = defaults( b, a );
+    var c = defaults(a, b);
 
     expect(c).to.eql({
       foo: 1,
+      bar: 2,
+      qux: 3
+    });
+
+    done();
+  });
+
+  it('should return target if source does not exist', function(done) {
+    var a = null;
+
+    var b = {
+      foo: 1,
+      bar: 2,
+      qux: 3
+    };
+
+    var c = defaults(b, a);
+
+    expect(c).to.eql({
+      foo: 1,
+      bar: 2,
+      qux: 3
+    });
+
+    done();
+  });
+
+  it('should support partial functionality', function(done) {
+    var a = {
+      foo: 10
+    };
+
+    var b = {
+      foo: 1,
+      bar: 2,
+      qux: 3
+    };
+
+    var partial = defaults(b);
+    var c = partial(a);
+
+    expect(c).to.eql({
+      foo: 10,
       bar: 2,
       qux: 3
     });

--- a/test/test-pick.js
+++ b/test/test-pick.js
@@ -40,6 +40,22 @@ describe('pick', function () {
     });
     expect(pick(obj)).to.eql({});
     expect(pick(obj, [])).to.eql({});
+    expect(pick(obj, RegExp('a'))).to.eql({
+      bar: 1
+    });
+    expect(pick(obj, RegExp('a'), 'foo')).to.eql({
+      foo: 1,
+      bar: 1
+    });
+    expect(pick(obj, [RegExp('q|b')], 'bar')).to.eql({
+      bar: 1,
+      qux: 1
+    });
+    expect(pick(obj, [RegExp('q'), RegExp('f')], ['bar'])).to.eql({
+      foo: 1,
+      bar: 1,
+      qux: 1
+    });
     done();
   });
   it('should pick keys from objects in an array when used with map', function(done) {
@@ -128,6 +144,55 @@ describe('pick', function () {
       {
         foo: 2,
         bar: 2,
+        qux: 2
+      },
+      {
+        foo: 3,
+        bar: 3
+      }
+    ]);
+    expect(objs.map(pick(RegExp('q|g')))).to.eql([
+      {},
+      {
+        qux: 2
+      },
+      {
+        goo: 3
+      }
+    ]);
+    expect(objs.map(pick(RegExp('BAR', 'i'), 'foo'))).to.eql([
+      {
+        bar: 1
+      },
+      {
+        foo: 2,
+        bar: 2
+      },
+      {
+        foo: 3,
+        bar: 3
+      }
+    ]);
+    expect(objs.map(pick([RegExp('b')], 'foo'))).to.eql([
+      {
+        bar: 1
+      },
+      {
+        foo: 2,
+        bar: 2
+      },
+      {
+        foo: 3,
+        bar: 3
+      }
+    ]);
+    expect(objs.map(pick([RegExp('b'), RegExp('q')], ['foo']))).to.eql([
+      {
+        bar: 1
+      },
+      {
+        bar: 2,
+        foo: 2,
         qux: 2
       },
       {

--- a/test/test-pick.js
+++ b/test/test-pick.js
@@ -56,6 +56,16 @@ describe('pick', function () {
       bar: 1,
       qux: 1
     });
+    expect(pick(obj, [RegExp('q'), 'foo'], 'bar')).to.eql({
+      foo: 1,
+      bar: 1,
+      qux: 1
+    });
+    expect(pick(obj, [RegExp('x$'), 'foo'], [RegExp('b')])).to.eql({
+      foo: 1,
+      bar: 1,
+      qux: 1
+    });
     done();
   });
   it('should pick keys from objects in an array when used with map', function(done) {
@@ -186,7 +196,7 @@ describe('pick', function () {
         bar: 3
       }
     ]);
-    expect(objs.map(pick([RegExp('b'), RegExp('q')], ['foo']))).to.eql([
+    expect(objs.map(pick([RegExp('b'), 'qux'], ['foo']))).to.eql([
       {
         bar: 1
       },
@@ -198,6 +208,21 @@ describe('pick', function () {
       {
         foo: 3,
         bar: 3
+      }
+    ]);
+    expect(objs.map(pick([RegExp('b'), RegExp('^f')], [RegExp('oo$')]))).to.eql([
+      {
+        bar: 1
+      },
+      {
+        bar: 2,
+        foo: 2
+      },
+      {
+        bar: 3,
+        foo: 3,
+        koo: 3,
+        goo: 3
       }
     ]);
     expect(objs.map(pick())).to.eql([


### PR DESCRIPTION
- can do pick with RegExp and strings.
``` javascript
var sampleObject = {a: 1, B: 2, C: 3, d: 4}
pick(sampleObject, RegExp('[A-Z]')); // {B:2, C:3}
```
- added `-t 100` to package.json to ensure 100% test coverage
