### PR TITLE
proposal to add curry function and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ converge(mul, [add, sub])(6, 2); // mul(add(6, 2), sub(6, 2)) // (6+2) * (6-2) =
 [f, converge(g, [h, i]), j].reduce(compose); // f(g(h(j), i(j)))
 ```
 
+## curry
+
+Returns a curried function.
+
+```js
+var curry = require('101/curry');
+
+function add(a, b) { return a + b; }
+
+var curriedAdd = curry(add);
+var add2 = curriedAdd(2);
+
+add2(6); // 8
+add2(8); // 10
+
+function join() { return Array.prototype.slice.call(arguments).join(''); }
+
+curry(join, 3)(1)(0)(1); // "101"
+```
+
 ## envIs
 
 Functional version of `str === process.env.NODE_ENV`.

--- a/curry.js
+++ b/curry.js
@@ -1,0 +1,32 @@
+/**
+ * @module 101/curry
+ */
+ 
+var slice = Array.prototype.slice;
+
+/**
+ * Returns a curried function
+ * @function module:101/curry
+ * @param {function} f - function to be curried
+ * @param {integer} [n] - how many arguments to curry
+ * @return {function} 
+ */
+module.exports = curry;
+
+function curry(f, n) {
+  var length = n || f.length;
+  return _curry(f, length, []);
+}
+
+function _curry(f, n, args) {
+
+  return function(/* args */) {
+    var curryArgs = args.concat(slice.call(arguments));
+
+    if (curryArgs.length >= n) {
+      return f.apply(null, curryArgs);
+    } else {
+      return _curry(f, n, curryArgs);
+    }
+  };
+}

--- a/test/test-curry.js
+++ b/test/test-curry.js
@@ -1,0 +1,64 @@
+var Lab = require('lab');
+var curry = require('../curry');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var beforeEach = lab.beforeEach;
+var expect = Lab.expect;
+
+describe('curry', function() {
+  var x, y, f, g, h;
+
+  beforeEach(function(done) {
+    var slice = Array.prototype.slice;
+
+    f = function(a) {
+      return a;
+    };
+
+    g = function(a, b) {
+      return a + b;
+    };
+
+    h = function() {
+      return slice.call(arguments).join();
+    };
+
+    x = Math.random();
+    y = Math.random();
+
+    done();
+  });
+
+  it('curry(f)(1) should be identical to f(1)', function(done) {
+    var expected = f(x);
+    var curryF = curry(f);
+    var actual = curryF(x);
+    expect(actual).to.eql(expected);
+    done();
+  });
+
+  it('curry(g)(1)(2) should be identical to g(1, 2)', function(done) {
+    var expected = g(x, y);
+    var curryG = curry(g);
+    var actual = curryG(x)(y);
+    expect(actual).to.eql(expected);
+    done();
+  });
+
+  it('curry(g)(1, 2) should be identical to g(1, 2)', function(done) {
+    var expected = g(x, y);
+    var curryG = curry(g);
+    var actual = curryG(x, y);
+    expect(actual).to.eql(expected);
+    done();
+  });
+
+  it('curry(h, 3)(1, 2, 3) should be identical to h(1, 2, 3)', function(done) {
+    var expected = h(x, y, y);
+    var curryH = curry(h, 3);
+    var actual = curryH(x, y, y);
+    expect(actual).to.eql(expected);
+    done();
+  });
+});


### PR DESCRIPTION
This adds a simple `curry` function that takes either just a function or a function and an integer and returns `n` curried functions.
@tjmehta What do you think about adding this to the lib?


```js
var curry = require('101/curry');

function add(a, b) { return a + b; }

var curriedAdd = curry(add);
var add2 = curriedAdd(2);

add2(6); // 8
add2(8); // 10

function join() { return Array.prototype.slice.call(arguments).join(''); }

curry(join, 3)(1)(0)(1); // "101"
```