### PR TITLE
ES6 Object.is w/ MDN defined polyfill alternative in 101/equals implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ envIs('development', 'production'); // true
 
 ## equals
 
-Functional implementation of Object.is with polyfill
+Functional implementation of Object.is with polyfill for browsers without implementations of Object.is
 Supports partial functionality (great with array functions).
 
 ```js

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ envIs('development', 'production'); // true
 
 ## equals
 
-Functional version of `===`.
+Functional implementation of Object.is with polyfill
 Supports partial functionality (great with array functions).
 
 ```js

--- a/equals.js
+++ b/equals.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * Functional version of ===
+ * Functional implementation of Object.is with polyfill for browsers without implementations of Object.is
  * @function module:101/equals
  * @param {*} a - any value
  * @param {*} b - any value

--- a/equals.js
+++ b/equals.js
@@ -18,6 +18,19 @@ module.exports = function (a, b) {
   }
 };
 
-function equals (a, b) {
-  return a === b;
+function equals (v1, v2) {
+  if (Object.is) {
+    return Object.is(v1, v2);
+  }
+  else {
+    // ES6 Object.is polyfill
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+    if (v1 === 0 && v2 === 0) {
+      return 1 / v1 === 1 / v2;
+    }
+    if (v1 !== v1) {
+      return v2 !== v2;
+    }
+    return v1 === v2;
+  }
 }

--- a/equals.js
+++ b/equals.js
@@ -7,7 +7,7 @@
  * @function module:101/equals
  * @param {*} a - any value
  * @param {*} b - any value
- * @return {boolean} a === b
+ * @return {boolean} Object.is(a, b)
  */
 module.exports = function (a, b) {
   if (arguments.length === 1) {

--- a/test/test-equals.js
+++ b/test/test-equals.js
@@ -18,7 +18,7 @@ describe('equals', function() {
       [2, '3'],
       [obj, {}],
       [false, ''],
-      [+1, -1],
+      [+0, -0],
       [Number.NaN, NaN],
       [0, 0]
     ];

--- a/test/test-equals.js
+++ b/test/test-equals.js
@@ -19,7 +19,8 @@ describe('equals', function() {
       [obj, {}],
       [false, ''],
       [+1, -1],
-      [Number.NaN, NaN]
+      [Number.NaN, NaN],
+      [0, 0]
     ];
     compares.forEach(function (items) {
       expect(equals(items[0], items[1])).to.equal(Object.is(items[0], items[1]));

--- a/test/test-equals.js
+++ b/test/test-equals.js
@@ -8,7 +8,7 @@ var expect = Lab.expect;
 var equals = require('../equals');
 
 describe('equals', function() {
-  it('should work like ===', function (done) {
+  it('should work like Object.is', function (done) {
     var obj = {};
     var compares = [
       ['hey', 'hey'],
@@ -17,11 +17,20 @@ describe('equals', function() {
       ['hey', 'hey'],
       [2, '3'],
       [obj, {}],
-      [false, '']
+      [false, ''],
+      [+1, -1],
+      [Number.NaN, NaN]
     ];
     compares.forEach(function (items) {
-      expect(equals(items[0], items[1])).to.equal(items[0] === items[1]);
+      expect(equals(items[0], items[1])).to.equal(Object.is(items[0], items[1]));
     });
+    // Monkey patching Object.is, better way?
+    var temp = Object.is;
+    Object.is = false;
+    compares.forEach(function (items) {
+      expect(equals(items[0], items[1])).to.equal(temp(items[0], items[1]));
+    });
+    Object.is = temp;
     done();
   });
   it('should works with array functions', function (done) {


### PR DESCRIPTION
Object.is supposedly superior equality comparator to '==='
Supported in node v0.12.0 (without --harmony flag), Chrome, Firefox
Part of ES6 proposal

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
`This is also not the same as being equal according to the === operator. The === operator (and the == operator as well) treats the number values -0 and +0 as equal and treats Number.NaN as not equal to NaN.`