### PR TITLE
pick, with keypaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,11 @@ Supports regular expressions and partial functionality (great with array functio
 var pick = require('101/pick');
 var obj = {
   foo: 1,
-  bar: 2
+  bar: 2,
+  qwk: {
+    wrk: 1
+  },
+  'qwk.wrk': 2
 };
 
 pick(obj, 'foo');          // { foo: 1 }
@@ -644,6 +648,10 @@ pick(obj, ['foo', 'bar']); // { foo: 1, bar: 2 }
 
 // use it with array.map
 [obj, obj, obj].map(pick('foo')); // [{ foo: 1 }, { foo: 1 }, { foo: 1 }];
+
+// supports keypaths
+pick(obj, 'qwk.wrk');      // { qwk: { wrk: 1 } }
+pick(obj, '["qwk.wrk"]');  // { 'qwk.wrk': 2 } }
 ```
 
 ## pluck

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "homepage": "https://github.com/tjmehta/101",
   "devDependencies": {
     "code": "^1.4.0",
-    "lab": "^5.5.1"
+    "lab": "^5.9.0"
   },
   "dependencies": {
     "clone": "^0.1.18",
     "deep-eql": "^0.1.3",
-    "keypather": "^1.8.1"
+    "keypather": "^1.10.1"
   }
 }

--- a/pick.js
+++ b/pick.js
@@ -4,6 +4,8 @@
 
 var isObject = require('./is-object');
 var isRegExp = require('./is-regexp');
+var keypather = require('keypather')();
+var exists = require('./exists');
 
 /**
  * Returns a new object with the specified keys (with key values from obj).
@@ -45,8 +47,9 @@ function copy (from, to) {
         }
       });
     } else {
-      if (key in from) {
-        to[key] = from[key];
+      var val = keypather.get(from, key);
+      if (exists(val)) {
+        keypather.set(to, key, val);
       }
     }
   };

--- a/pick.js
+++ b/pick.js
@@ -41,9 +41,10 @@ function pick (obj, args) {
 function copy (from, to) {
   return function (key) {
     if (isRegExp(key)) {
-      Object.keys(from).forEach(function(keyFrom) {
-        if (key.test(keyFrom)) {
-          to[keyFrom] = from[keyFrom];
+      var flatFrom = keypather.flatten(from);
+      Object.keys(flatFrom).forEach(function(keypathFrom) {
+        if (key.test(keypathFrom)) {
+          keypather.set(to, keypathFrom, keypather.get(from, keypathFrom));
         }
       });
     } else {

--- a/test/test-pick.js
+++ b/test/test-pick.js
@@ -69,6 +69,21 @@ describe('pick', function () {
     });
     done();
   });
+  it('should pick keys from objects when using keypaths', function(done) {
+    var obj = {
+      koo: 1,
+      qux: 1,
+      fiz: {
+        buz: 1
+      },
+      'fiz.buz': 2
+    };
+    expect(pick(obj, 'fiz')).to.eql({ fiz: { buz: 1 } });
+    expect(pick(obj, 'fiz.buz')).to.eql({ fiz: { buz: 1 } });
+    expect(pick(obj, '["fiz.buz"]')).to.eql({ 'fiz.buz': 2 });
+    expect(pick(obj, 'fiz.nop')).to.eql({});
+    done();
+  });
   it('should pick keys from objects in an array when used with map', function(done) {
     var objs = [
       {

--- a/test/test-pick.js
+++ b/test/test-pick.js
@@ -78,10 +78,113 @@ describe('pick', function () {
       },
       'fiz.buz': 2
     };
-    expect(pick(obj, 'fiz')).to.eql({ fiz: { buz: 1 } });
-    expect(pick(obj, 'fiz.buz')).to.eql({ fiz: { buz: 1 } });
-    expect(pick(obj, '["fiz.buz"]')).to.eql({ 'fiz.buz': 2 });
-    expect(pick(obj, 'fiz.nop')).to.eql({});
+    expect(pick(obj, 'fiz')).to.deep.equal({ fiz: { buz: 1 } });
+    expect(pick(obj, 'fiz.buz')).to.deep.equal({ fiz: { buz: 1 } });
+    expect(pick(obj, '["fiz.buz"]')).to.deep.equal({ 'fiz.buz': 2 });
+    expect(pick(obj, 'fiz.nop')).to.deep.equal({});
+    done();
+  });
+  it('should pick keys/keypaths from objects using RegExp', function (done) {
+    var objs = [
+      {
+        bar: 1
+      },
+      {
+        foo: 2,
+        bar: 2,
+        qux: 2
+      },
+      {
+        foo: 3,
+        bar: 3,
+        koo: 3,
+        goo: 3
+      },
+      {
+        deep: {
+          keypath: 1
+        }
+      }
+    ];
+    expect(objs.map(pick(RegExp('q|g')))).to.deep.equal([
+      {},
+      {
+        qux: 2
+      },
+      {
+        goo: 3
+      },
+      { }
+    ]);
+    expect(objs.map(pick(RegExp('BAR', 'i'), 'foo'))).to.deep.equal([
+      {
+        bar: 1
+      },
+      {
+        foo: 2,
+        bar: 2
+      },
+      {
+        foo: 3,
+        bar: 3
+      },
+      { }
+    ]);
+    expect(objs.map(pick([RegExp('b')], 'foo'))).to.deep.equal([
+      {
+        bar: 1
+      },
+      {
+        foo: 2,
+        bar: 2
+      },
+      {
+        foo: 3,
+        bar: 3
+      },
+      { }
+    ]);
+    expect(objs.map(pick([RegExp('b'), 'qux'], ['foo']))).to.deep.equal([
+      {
+        bar: 1
+      },
+      {
+        bar: 2,
+        foo: 2,
+        qux: 2
+      },
+      {
+        foo: 3,
+        bar: 3
+      },
+      { }
+    ]);
+    expect(objs.map(pick([RegExp('b'), RegExp('^f')], [RegExp('oo$')]))).to.deep.equal([
+      {
+        bar: 1
+      },
+      {
+        bar: 2,
+        foo: 2
+      },
+      {
+        bar: 3,
+        foo: 3,
+        koo: 3,
+        goo: 3
+      },
+      { }
+    ]);
+    expect(objs.map(pick([RegExp('^d')]))).to.deep.equal([
+      { },
+      { },
+      { },
+      {
+        deep: {
+          keypath: 1
+        }
+      },
+    ]);
     done();
   });
   it('should pick keys from objects in an array when used with map', function(done) {
@@ -175,70 +278,6 @@ describe('pick', function () {
       {
         foo: 3,
         bar: 3
-      }
-    ]);
-    expect(objs.map(pick(RegExp('q|g')))).to.deep.equal([
-      {},
-      {
-        qux: 2
-      },
-      {
-        goo: 3
-      }
-    ]);
-    expect(objs.map(pick(RegExp('BAR', 'i'), 'foo'))).to.deep.equal([
-      {
-        bar: 1
-      },
-      {
-        foo: 2,
-        bar: 2
-      },
-      {
-        foo: 3,
-        bar: 3
-      }
-    ]);
-    expect(objs.map(pick([RegExp('b')], 'foo'))).to.deep.equal([
-      {
-        bar: 1
-      },
-      {
-        foo: 2,
-        bar: 2
-      },
-      {
-        foo: 3,
-        bar: 3
-      }
-    ]);
-    expect(objs.map(pick([RegExp('b'), 'qux'], ['foo']))).to.deep.equal([
-      {
-        bar: 1
-      },
-      {
-        bar: 2,
-        foo: 2,
-        qux: 2
-      },
-      {
-        foo: 3,
-        bar: 3
-      }
-    ]);
-    expect(objs.map(pick([RegExp('b'), RegExp('^f')], [RegExp('oo$')]))).to.deep.equal([
-      {
-        bar: 1
-      },
-      {
-        bar: 2,
-        foo: 2
-      },
-      {
-        bar: 3,
-        foo: 3,
-        koo: 3,
-        goo: 3
       }
     ]);
     expect(objs.map(pick())).to.deep.equal([


### PR DESCRIPTION
now pick can be used with keypather to get specific fields of sub-objects if one so desired