### PR TITLE
[wip] hasKeypaths additional documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,10 +283,18 @@ hasKeypaths(obj, { 'foo.bar': barObj }, true);   // true
 hasKeypaths(obj, { 'foo.bar': barObj }, false);  // false
 hasKeypaths(obj, { 'foo.bar': obj.foo }, false); // true
 hasKeypaths(obj, ['foo.bar'], false);            // true, uses [hasOwnProperty vs in](http://stackoverflow.com/questions/13632999/if-key-in-object-or-ifobject-hasownpropertykey)
+
 // use it with find, findIndex, or filter!
 var arr = [obj, { b: 1 }, { c: 1 }];
 find(arr, hasProps({ 'foo.bar.qux':1 })); // { foo: { bar: { qux: 1 } } }
 find(arr, hasProps(['foo.bar.qux']));     // { foo: { bar: { qux: 1 } } }
+
+// use it to verify options object has required properties
+var opts = {
+  host: 'localhost',
+  port: '3333'
+};
+hasKeypaths(opts, ['host', 'port']); // true
 ```
 
 ## hasProperties

--- a/README.md
+++ b/README.md
@@ -286,15 +286,19 @@ hasKeypaths(obj, ['foo.bar'], false);            // true, uses [hasOwnProperty v
 
 // use it with find, findIndex, or filter!
 var arr = [obj, { b: 1 }, { c: 1 }];
-find(arr, hasProps({ 'foo.bar.qux':1 })); // { foo: { bar: { qux: 1 } } }
-find(arr, hasProps(['foo.bar.qux']));     // { foo: { bar: { qux: 1 } } }
+find(arr, hasKeypaths({ 'foo.bar.qux':1 })); // { foo: { bar: { qux: 1 } } }
+find(arr, hasKeypaths(['foo.bar.qux']));     // { foo: { bar: { qux: 1 } } }
 
 // use it to verify options object has required properties
 var opts = {
   host: 'localhost',
-  port: '3333'
+  port: '3333',
+  user: {
+    id: 5
+  }
 };
-hasKeypaths(opts, ['host', 'port']); // true
+hasKeypaths(opts, ['host', 'port', 'user.id']); // true
+
 ```
 
 ## hasProperties


### PR DESCRIPTION
hasKeypaths README documentation did not have an example for a popular use case of hasKeypaths, verifying object has [0..n] defined required properties. Existing examples only demonstrated asserting 1 keypath. 