### PR TITLE
add restParam function and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,20 @@ obj; // { foo: 1, bar: 2 } (not modified)
 obj; // { foo: 1, bar: 2 } (not modified)
 ```
 
+## restParam
+
+Returns a function with an appended rest param
+
+```js
+var restParam = require('101/rest-param');
+
+restParam(function(a, b, rest) {
+  console.log(a); // 1
+  console.log(b); // 2
+  console.log(rest); // [3, 4]
+})(1, 2, 3, 4);
+```
+
 ## set
 
 Functional version of obj[key] = val, returns the same obj with the key and value set.

--- a/rest-param.js
+++ b/rest-param.js
@@ -1,0 +1,22 @@
+/**
+ * @module 101/rest-param
+ */
+
+var slice = Array.prototype.slice;
+
+/**
+ * Returns a function with an appended rest param
+ * @function module:101/rest-param
+ * @param {function} f - function append a rest param
+ * @return {function}
+ */
+module.exports = function(f) {
+  var pos = f.length - 1;
+
+  return function() {
+    var params = slice.call(arguments, 0, pos);
+
+    params[pos] = slice.call(arguments, pos);
+    return f.apply(this, params);
+  };
+};

--- a/test/test-rest-param.js
+++ b/test/test-rest-param.js
@@ -1,0 +1,48 @@
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+
+var describe = lab.describe;
+var it = lab.it;
+var Code = require('code');
+var expect = Code.expect;
+
+var restParam = require('../rest-param');
+
+describe('rest-param', function () {
+  it('should append an array with the rest params to a function', function(done) {
+    restParam(function(rest) {
+      expect(rest).to.deep.equal([1, 2, 3]);
+    })(1, 2, 3);
+
+    restParam(function(a, rest) {
+      expect(a).to.equal(1);
+      expect(rest).to.deep.equal([2, 3]);
+    })(1, 2, 3);
+
+    restParam(function(a, b, rest) {
+      expect(a).to.equal(1);
+      expect(b).to.equal(2);
+      expect(rest).to.deep.equal([3, 4]);
+    })(1, 2, 3, 4);
+
+    restParam(function(a, b, rest) {
+      expect(a).to.equal(1);
+      expect(b).to.equal(2);
+      expect(rest).to.deep.equal([]);
+    })(1, 2);
+
+    restParam(function(a, b, rest) {
+      expect(a).to.equal(1);
+      expect(b).to.equal(undefined);
+      expect(rest).to.deep.equal([]);
+    })(1);
+
+    restParam(function(a, b, rest) {
+      expect(a).to.equal(undefined);
+      expect(b).to.equal(undefined);
+      expect(rest).to.deep.equal([]);
+    })();
+
+    done();
+  });
+});


### PR DESCRIPTION
This adds a function to append a given function with a rest parameter.

```js
var restParam = require('101/rest-param');

restParam(function(a, b, rest) {
  console.log(a); // 1
  console.log(b); // 2
  console.log(rest); // [3, 4]
})(1, 2, 3, 4);
```

Would be nice to get some feedback on the wording in the description (readme and jsdoc).
I'm not sure if it's clear enough what the function does.