### PR TITLE
lab expectations assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "common javascript utils that can be required selectively that assume es5+",
   "main": "index.js",
   "scripts": {
-    "test": "lab -c -t 100 test",
+    "test": "lab -c -t 100 -a code test",
     "test-watch": "nodemon --exec lab -c test"
   },
   "repository": {

--- a/test/test-del.js
+++ b/test/test-del.js
@@ -100,7 +100,7 @@ describe('del', function () {
         del(/what/, /what/);
       }
       catch (err) {
-        expect(err).to.be.ok;
+        expect(err).to.exist();
         done();
       }
     });

--- a/test/test-env-is.js
+++ b/test/test-env-is.js
@@ -11,17 +11,17 @@ var envIs = require('../env-is');
 describe('envIs', function() {
   it('should return true when the argument matches the environment', function (done) {
     process.env.NODE_ENV='test';
-    expect(envIs('test')).to.be.ok;
+    expect(envIs('test')).to.equal(true);
     done();
   });
   it('should return false when the argument doesnt match the environment', function (done) {
     process.env.NODE_ENV='test';
-    expect(envIs('development')).to.not.be.ok;
+    expect(envIs('development')).to.equal(false);
     done();
   });
   it('should "or" if passed multiple environments', function (done) {
     process.env.NODE_ENV='test';
-    expect(envIs('development', 'test')).to.be.ok;
+    expect(envIs('development', 'test')).to.equal(true);
     done();
   });
 });

--- a/test/test-put.js
+++ b/test/test-put.js
@@ -130,26 +130,26 @@ describe('put', function () {
 
     var result = put(obj, key, val);
     expect(result).to.deep.equal(expected);
-    expect(result instanceof Date).to.be.ok;
+    expect(result instanceof Date).to.equal(true);
     done();
   });
 
   describe('errors', function() {
     it('should error when given two args other than (key, value) or (obj, putObj)', function (done) {
-      try {put(/whatever/, /whatever/);}
-      catch (err) {expect(err).to.be.ok;}
+      try { put(/whatever/, /whatever/); }
+      catch (err) { expect(err).to.exist(); }
       done();
     });
 
     it('should error when given no args', function (done) {
-      try {put();}
-      catch (err) {expect(err).to.be.ok;}
+      try { put(); }
+      catch (err) { expect(err).to.exist(); }
       done();
     });
 
     it('should error when one arg other than putObj', function (done) {
-      try {put("anything");}
-      catch (err) {expect(err).to.be.ok;}
+      try { put("anything"); }
+      catch (err) { expect(err).to.exist(); }
       done();
     });
   });

--- a/test/test-set.js
+++ b/test/test-set.js
@@ -111,7 +111,7 @@ describe('set', function () {
         set(/what/, /what/);
       }
       catch (err) {
-        expect(err).to.be.ok;
+        expect(err).to.exist();
         done();
       }
     });


### PR DESCRIPTION
`lab`, it turns out, doesn't actually assert that all the `expects()` are called unless you include `-a code` into the `lab` command. This adds that command to the `npm test` script, and fixes the various incomplete `expects` statements.