### PR TITLE
isNumber Now Returns False on NaN

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,12 +457,12 @@ var isFunction = require('101/is-function');
 
 ## isNumber
 
-Functional version of val typeof 'number'
+Functional version of val typeof 'number'.
 
 ```js
 var isNumber = require('101/is-number');
 
-['foo', 'bar', 1].map(isNumber); // [false, false, true]
+['foo', NaN, 1].map(isNumber); // [false, false, true]
 ```
 
 ## isObject

--- a/is-number.js
+++ b/is-number.js
@@ -11,5 +11,5 @@
 module.exports = isNumber;
 
 function isNumber (val) {
-  return typeof val === 'number' || val instanceof Number;
+  return !isNaN(val) && (typeof val === 'number' || val instanceof Number);
 }

--- a/test/test-is-number.js
+++ b/test/test-is-number.js
@@ -24,6 +24,7 @@ describe('isNumber', function () {
     expect(isNumber(null)).to.be.false();
     expect(isNumber(undefined)).to.be.false();
     expect(isNumber(new String('hey'))).to.be.false();
+    expect(isNumber(NaN)).to.be.false();
     done();
   });
 });


### PR DESCRIPTION
Changes the `isNumber` function to return false when given a value of `NaN`. Baseically it was failing because `NaN` is technically an instance of Number.