### PR TITLE
Improve keysIn

### DIFF
--- a/keys-in.js
+++ b/keys-in.js
@@ -13,11 +13,17 @@ module.exports = keysIn;
 
 function keysIn(object) {
   if (!object) { return []; }
-
-  var keys = [];
-  for (var key in object) {
-    keys.push(key);
+  
+  if (Object.keys) {
+    return Object.keys(object);
+  } else {
+   var keys = [];
+    for (var key in object) {
+      if (object.hasOwnProperty(key)) {
+        keys.push(key);
+      }
+    }
+  
+    return keys; 
   }
-
-  return keys;
 }


### PR DESCRIPTION
Improves `keysIn` method:

- Use [`Object.keys`][docs] when available
- Add `hasOwnProperty` check to the object keys loop

[docs]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/keys