### PR TITLE
fix put keypath

### DIFF
--- a/put.js
+++ b/put.js
@@ -50,7 +50,7 @@ function put (obj, key, val) {
   }
   else {
     setObj = {};
-    keypather.set(setObj, key, val);
+    setObj[key] = val
     return putKeypaths(obj, setObj); // extends original
   }
 }

--- a/test/test-put.js
+++ b/test/test-put.js
@@ -119,6 +119,46 @@ describe('put', function () {
     done();
   });
 
+  describe('keypaths', function () {
+    it('should put via keypath object', function (done) {
+      console.log('hello')
+      var obj = {
+        foo: {
+          bar: 1
+        }
+      }
+      var expected = {
+        foo: {
+          bar: 1,
+          qux: 1
+        },
+        yolo: {
+          dolo: 1
+        }
+      }
+      var out = put(obj, { 'foo.qux': 1, 'yolo.dolo': 1 })
+      expect(out).to.deep.equal(expected)
+      done();
+    });
+
+    it('should put via keypath and val', function (done) {
+      var obj = {
+        foo: {
+          bar: 1
+        }
+      }
+      var expected = {
+        foo: {
+          bar: 1,
+          qux: 1
+        }
+      }
+      var out = put(obj, 'foo.qux', 1)
+      expect(out).to.deep.equal(expected)
+      done();
+    });
+  });
+
   it("shouldn't change the type of the object", function(done) {
     var obj = new Date();
 


### PR DESCRIPTION
```js
var obj = { foo: { bar: 1 } }
put(obj, 'foo.qux', true)
// bug, overwrites nested obj
// { foo: { qux: true } }
```
