### PR TITLE
Implement merge

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -1,0 +1,45 @@
+/**
+ * @module 101/put
+ */
+
+var clone = require("./clone");
+var assign = require("./assign");
+var keypather = require('keypather')();
+
+/**
+ * A merge-version of `put`.
+ * When only key and val are specified, merge returns a partial function which accepts obj.
+ * @function module:101/merge
+ * @param {*} [obj] - object which will be cloned and assigned with {key: value}
+ * @param {string|number} key - key of the value being merged on obj
+ * @param {*} val - value of the key being merged on obj
+ * @return {*|function} New obj with new value set or Partial-function merge (which accepts obj) and returns a new obj with val set
+ */
+ 
+module.exports = merge;
+
+function merge (obj, key, val) {
+  if (arguments.length === 1) {
+    val = obj
+    return function(obj) {
+      var set = clone(obj)
+      return assign(set, val);
+    }
+  }
+
+  if (arguments.length === 2) {
+    val = key;
+    key = obj;
+    return function(obj) {
+      var set = clone(obj);
+      keypather.set(set, key, val)
+      return set;
+    }
+  }
+
+  var set = clone(obj);
+  var old = keypather.get(set, key);
+  var merged = assign(old, val)
+  keypather.set(set, key, merged);
+  return set;
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "common javascript utils that can be required selectively that assume es5+",
   "main": "index.js",
   "scripts": {
-    "test": "lab -c -t 100 -a code",
+    "test": "lab --leaks -c -t 100 -a code",
     "test-watch": "nodemon --exec lab -c"
   },
   "repository": {

--- a/test/test-merge.js
+++ b/test/test-merge.js
@@ -1,0 +1,66 @@
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+
+var describe = lab.describe;
+var it = lab.it;
+var Code = require('code');
+var expect = Code.expect;
+
+var clone = require('../clone');
+// var put = require('../put');
+// var set = require('../set');
+
+var merge = require('../merge');
+
+describe('merge', function () {
+  it('should merge the value with the current value on a new object', function(done) {
+    var obj = {
+      comments: [{
+        replies: [{
+          text: 'Hey, swag'
+        }]
+      }]
+    };
+
+    var original = clone(obj);
+    var expected = clone(obj);
+    expected.comments[0].replies[0].text = 'Hi, swag';
+
+    const merged = merge(obj, 'comments.0.replies.0', { text: 'Hi, swag' });
+    expect(merged).to.deep.equal(expected);
+    expect(merged).not.to.equal(obj);
+    done();
+  });
+
+  it('should merge a value when used with array functions', function(done) {
+    var obj = [
+      { id: 2, online: false },
+      { id: 3, online: false }
+    ];
+
+    var expected = clone(obj);
+    expected[0].online = true;
+    expected[1].online = true;
+
+    var merged = obj.map(merge({ online: true }));
+    expect(merged).to.deep.equal(expected);
+    expect(merged).not.to.deep.equal(obj);
+    done();
+  });
+
+  it('should merge a key-value set on when used with array functions', function(done) {
+    var obj = [
+      { id: 2, user: { online: false } },
+      { id: 3, user: { online: false } }
+    ];
+
+    var expected = clone(obj);
+    expected[0].user.online = true;
+    expected[1].user.online = true;
+
+    var merged = obj.map(merge('user', { online: true }));
+    expect(merged).to.deep.equal(expected);
+    expect(merged).not.to.deep.equal(obj);
+    done();
+  });
+});


### PR DESCRIPTION
For #151

## Supported
- [x] merge({ text })`
- [x] `merge('fetch', { loading: false })`
- [x] `merge(state.comments, '34.replies.5', { text })`

## Todo
- [ ] Value keypaths (`merge(state.comments, { '0.replies.1': { text } })`)
- [ ] Argument validation
- [ ] Docs

-----

I think I need some help. I'm honestly not sure what things we need to implement. There are a number of things `put` does well already that I don't think merge should.