### PR TITLE
CVE 2021 25943 fix2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "101",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "common javascript utils that can be required selectively that assume es5+",
   "main": "index.js",
   "scripts": {

--- a/set.js
+++ b/set.js
@@ -19,6 +19,9 @@ var keypather = require('keypather')();
 module.exports = set;
 
 function set (obj, key, val) {
+  if (key === '__proto__' || key === 'prototype' || key === 'constructor') {
+    return
+  }
   var setObj;
   if (arguments.length === 1) {
     // (setObj)

--- a/test/test-put.js
+++ b/test/test-put.js
@@ -121,7 +121,6 @@ describe('put', function () {
 
   describe('keypaths', function () {
     it('should put via keypath object', function (done) {
-      console.log('hello')
       var obj = {
         foo: {
           bar: 1

--- a/test/test-set.js
+++ b/test/test-set.js
@@ -165,6 +165,27 @@ describe('set', function () {
         expect(err).to.exist();
         done();
       }
+    }); 
+    it('should do nothing when when using __proto__ reserved key', function (done) {
+        target = {}
+        saved = target.__proto__
+        set(target, "__proto__", null);
+        expect(target.__proto__).to.equal(saved);
+        done();
+    });
+    it('should do nothing when using prototype reserved key', function (done) {
+      target = {}
+      saved = target.prototype
+      set(target, "prototype", null);
+      expect(target.prototype).to.equal(saved);
+      done()
+    });
+    it('should do nothing when using constructor reserved key', function (done) {
+      target = {}
+      saved = target.constructor
+      set(target, "constructor", null);
+      expect(target.constructor).to.equal(saved);
+      done()
     });
   });
 });


### PR DESCRIPTION
Hi,

The CVE-2021-25943 security is now 1 year old and raises npm audit issues.

So, I applied the following recommandation:

#159 (comment)

with units tests into this pull request.

Nothing else has been changed. The npm test is still 100%:
`

101@1.6.4 test
lab -c -l -t 100 -a code
..................................................
..................................................
..................................................
...............
165 tests complete
Test duration: 58 ms
Assertions count: 608 (verbosity: 3.68)
Coverage: 100.00%
Can you please accept this PR and publish an npm package accordingly ?

Note that I changed the implementation after review with my team, I silently ignore set with forbidden keys like in https://github.com/tjmehta/keypather/pull/43/files instead of throwing an error.
Test have been updated accordingly.